### PR TITLE
feat: mock svg preview and dev origins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+MONGODB_URI="mongodb+srv://USER:PASS@HOST/ai_meme?retryWrites=true&w=majority&appName=APP"
+OPENAI_API_KEY="sk-xxxxxxxx"
+IMAGE_MOCK_MODE=true
+NEXT_PUBLIC_BASE_URL="http://localhost:3000"
+ALLOWED_DEV_ORIGINS="http://192.168.56.1:3000"

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,10 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  // allows e.g. http://192.168.x.x:3000 in dev
+  allowedDevOrigins: process.env.ALLOWED_DEV_ORIGINS
+    ? process.env.ALLOWED_DEV_ORIGINS.split(",").map((s) => s.trim())
+    : undefined,
 };
 
 export default nextConfig;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -36,10 +36,19 @@ export default function Home() {
       const res = await fetch("/api/generate", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
+        cache: "no-store",
         body: JSON.stringify({ prompt }),
       });
       const data = await res.json();
-      setImageUrl(data.imageUrl || "");
+      console.log("generate =>", data);
+      if (res.ok && data?.imageUrl) {
+        const url = String(data.imageUrl);
+        setImageUrl(
+          url.startsWith("data:")
+            ? url
+            : url + (url.includes("?") ? "&" : "?") + `_ts=${Date.now()}`
+        );
+      }
     } finally {
       setLoading(false);
     }
@@ -111,6 +120,10 @@ export default function Home() {
               src={imageUrl}
               alt="preview"
               className="object-cover w-full h-full"
+              onError={(e) => {
+                (e.currentTarget as HTMLImageElement).src =
+                  "data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='800' height='500'%3E%3Crect width='100%25' height='100%25' fill='%23222'/%3E%3Ctext x='50%25' y='50%25' fill='white' text-anchor='middle' font-size='32' font-family='Arial'%3EImage failed%3C/text%3E%3C/svg%3E";
+              }}
             />
           )}
           {topText && (


### PR DESCRIPTION
## Summary
- mock image generation with inline SVG data URLs when OpenAI is unavailable or mock mode is enabled
- strengthen client preview with cache-busting, console logging, and image fallback
- allow LAN access in dev via `allowedDevOrigins` and document new env vars

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: interactive ESLint setup prompt)


------
https://chatgpt.com/codex/tasks/task_e_689d9ea155fc833092837ba454315eb2